### PR TITLE
Use html.escape instead of cgi.escape on Python 3.

### DIFF
--- a/pytest_html/plugin.py
+++ b/pytest_html/plugin.py
@@ -5,7 +5,6 @@
 from __future__ import absolute_import
 
 from base64 import b64encode
-import cgi
 import datetime
 import os
 import pkg_resources
@@ -19,8 +18,11 @@ from . import extras
 PY3 = sys.version_info[0] == 3
 
 # Python 2.X and 3.X compatibility
-if not PY3:
+if PY3:
+    from html import escape
+else:
     from codecs import open
+    from cgi import escape
 
 
 def pytest_addhooks(pluginmanager):
@@ -109,10 +111,10 @@ class HTMLReport(object):
                     else:
                         exception = line.startswith("E   ")
                         if exception:
-                            log.append(html.span(raw(cgi.escape(line)),
+                            log.append(html.span(raw(escape(line)),
                                                  class_='error'))
                         else:
-                            log.append(raw(cgi.escape(line)))
+                            log.append(raw(escape(line)))
                     log.append(html.br())
                 additional_html.append(log)
 


### PR DESCRIPTION
This fixes a `DeprecationWarning`:

```
[...]
  File "/home/buildbotx/slaves/slave/ubuntu-utopic/build/.tox/unittests/lib/python3.4/site-packages/pytest_html/plugin.py", line 115, in _appendrow
    log.append(raw(cgi.escape(line)))
  File "/usr/lib/python3.4/cgi.py", line 1039, in escape
    DeprecationWarning, stacklevel=2)
[...]
Message: '%s'
Arguments: ('/home/buildbotx/slaves/slave/ubuntu-utopic/build/.tox/unittests/lib/python3.4/site-packages/pytest_html/plugin.py:115: DeprecationWarning: cgi.escape is deprecated, use html.escape instead\n  log.append(raw(cgi.escape(line)))\n',)
```