### PR TITLE
Improve sorting

### DIFF
--- a/pytest_html/plugin.py
+++ b/pytest_html/plugin.py
@@ -199,7 +199,9 @@ class HTMLReport(object):
 
         results = [html.h2('Results'), html.table([html.thead(
             html.tr([
-                html.th('Result', class_='sortable', col='result'),
+                html.th('Result',
+                        class_='sortable initial-sort',
+                        col='result'),
                 html.th('Test', class_='sortable', col='name'),
                 html.th('Duration',
                         class_='sortable numeric',

--- a/pytest_html/plugin.py
+++ b/pytest_html/plugin.py
@@ -200,7 +200,7 @@ class HTMLReport(object):
         results = [html.h2('Results'), html.table([html.thead(
             html.tr([
                 html.th('Result',
-                        class_='sortable initial-sort',
+                        class_='sortable initial-sort result',
                         col='result'),
                 html.th('Test', class_='sortable', col='name'),
                 html.th('Duration',

--- a/pytest_html/resources/main.js
+++ b/pytest_html/resources/main.js
@@ -23,10 +23,18 @@ function find_all(selector, elem) {
     return toArray(elem.querySelectorAll(selector));
 }
 
+function sort_column(elem) {
+    toggle_sort_states(elem);
+    var colIndex = toArray(elem.parentNode.childNodes).indexOf(elem);
+    var key = elem.classList.contains('numeric') ? key_num : key_alpha;
+    sort_table(elem, key(colIndex));
+}
+
 addEventListener("DOMContentLoaded", function() {
     reset_sort_headers();
 
     split_extra_onto_two_rows();
+    sort_column(find('.initial-sort'));
 
     find_all('.col-links a.image').forEach(function(elem) {
         elem.addEventListener("click",
@@ -57,10 +65,7 @@ addEventListener("DOMContentLoaded", function() {
     find_all('.sortable').forEach(function(elem) {
         elem.addEventListener("click",
                               function(event) {
-                                  toggle_sort_states(elem);
-                                  var colIndex = toArray(elem.parentNode.childNodes).indexOf(elem);
-                                  var key = elem.classList.contains('numeric') ? key_num : key_alpha;
-                                  sort_table(elem, key(colIndex));
+                                  sort_column(elem);
                               }, false)
     });
 

--- a/pytest_html/resources/main.js
+++ b/pytest_html/resources/main.js
@@ -26,7 +26,14 @@ function find_all(selector, elem) {
 function sort_column(elem) {
     toggle_sort_states(elem);
     var colIndex = toArray(elem.parentNode.childNodes).indexOf(elem);
-    var key = elem.classList.contains('numeric') ? key_num : key_alpha;
+    var key;
+    if (elem.classList.contains('numeric')) {
+        key = key_num;
+    } else if (elem.classList.contains('result')) {
+        key = key_result;
+    } else {
+        key = key_alpha;
+    }
     sort_table(elem, key(colIndex));
 }
 
@@ -113,6 +120,14 @@ function key_alpha(col_index) {
 function key_num(col_index) {
     return function(elem) {
         return parseFloat(elem.childNodes[col_index].firstChild.data);
+    };
+}
+
+function key_result(col_index) {
+    return function(elem) {
+        var strings = ['Error', 'Failed', 'XFailed', 'XPassed', 'Skipped',
+                       'Passed'];
+        return strings.indexOf(elem.childNodes[col_index].firstChild.data);
     };
 }
 


### PR DESCRIPTION
This sorts tests by the results column by default, and defines a custom sorting which shows the tests roughly in order of importance so failed/skipped tests stand out from (hopefully many) passed ones.

Note I didn't write much javascript before that, so a thorough review is appreciated - it seems to work fine for me though.

A new release after this would be appreciated :wink: