### PR TITLE
Fix unencodable strings for Python 3.

### DIFF
--- a/pytest_html/plugin.py
+++ b/pytest_html/plugin.py
@@ -247,7 +247,13 @@ class HTMLReport(object):
         doc = html.html(head, body)
 
         logfile.write('<!DOCTYPE html>')
-        logfile.write(doc.unicode(indent=2))
+        unicode_doc = doc.unicode(indent=2)
+        if PY3:
+            # Fix encoding issues, e.g. with surrogates
+            unicode_doc = unicode_doc.encode('utf-8',
+                                             errors='xmlcharrefreplace')
+            unicode_doc = unicode_doc.decode('utf-8')
+        logfile.write(unicode_doc)
         logfile.close()
 
     def pytest_terminal_summary(self, terminalreporter):

--- a/test_pytest_html.py
+++ b/test_pytest_html.py
@@ -241,3 +241,15 @@ class TestHTML:
         assert 'Environment' in html
         for c in content:
             assert c in html
+
+    def test_utf8_surrogate(self, testdir):
+        testdir.makepyfile(r"""
+            import pytest
+
+            @pytest.mark.parametrize('val', ['\ud800'])
+            def test_foo(val):
+                pass
+        """)
+        result, html = run(testdir)
+        assert result.ret == 0
+        assert_summary(html, passed=1)


### PR DESCRIPTION
(Hopefully) fixes #12.