### PR TITLE
Replace custom hook with fixture for setting environment section

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -43,14 +43,14 @@ Then run your tests with::
 Enhancing reports
 -----------------
 
-You can add an *Environment* section to the report by implementing the
-:code:`pytest_html_environment` hook and returning a dict representing the test
-environment. For example:
+You can add change the *Environment* section of the report by modifying
+``request.config._html.environment`` from a fixture:
 
 .. code-block:: python
 
-  def pytest_html_environment(config):
-      return {'foo': 'bar'}
+  @pytest.fixture(autouse=True)
+  def _environment(request):
+      request.config._html.environment.append(('foo', 'bar'))
 
 You can add details to the HTML reports by creating an 'extra' list on the
 report object. The following example adds the various types of extras using a

--- a/pytest_html/newhooks.py
+++ b/pytest_html/newhooks.py
@@ -1,7 +1,0 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
-
-def pytest_html_environment(config):
-    """ return dict representation of environment for HTML report."""

--- a/test_pytest_html.py
+++ b/test_pytest_html.py
@@ -224,6 +224,12 @@ class TestHTML:
         assert link in html
 
     def test_no_environment(self, testdir):
+        testdir.makeconftest("""
+            import pytest
+            @pytest.fixture(autouse=True)
+            def _environment(request):
+                request.config._html.environment = None
+        """)
         testdir.makepyfile('def test_pass(): pass')
         result, html = run(testdir)
         assert result.ret == 0
@@ -232,9 +238,11 @@ class TestHTML:
     def test_environment(self, testdir):
         content = (str(random.random()), str(random.random()))
         testdir.makeconftest("""
-            def pytest_html_environment(config):
-                return {'%s': %s}
-        """ % content)
+            import pytest
+            @pytest.fixture(autouse=True)
+            def _environment(request):
+                request.config._html.environment.append(('{0[0]}', '{0[1]}'))
+        """.format(content))
         testdir.makepyfile('def test_pass(): pass')
         result, html = run(testdir)
         assert result.ret == 0


### PR DESCRIPTION
@The-Compiler would you mind taking a look at this? It allows me to include duplicate row headers by avoiding dictionaries. It also removed the uneccessary custom hook.