### PR TITLE
Added support for bytes objects in Python 3.x

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,7 @@ Release Notes
 
 **1.8 (unreleased)**
 
+* Added support for ``bytes`` objects from Python 3.x
 * Dropped support for Python 3.2
 * Indicated setup and teardown in report
 * Fixed colour of errors in report

--- a/pytest_html/plugin.py
+++ b/pytest_html/plugin.py
@@ -71,7 +71,9 @@ def pytest_unconfigure(config):
 
 def data_uri(content, mime_type='text/plain', charset='utf-8'):
     if PY3:
-        data = b64encode(content.encode(charset)).decode('ascii')
+        if not isinstance(content, bytes):
+            content = content.encode(charset)
+        data = b64encode(content).decode('ascii')
     else:
         data = b64encode(content)
     return 'data:{0};charset={1};base64,{2}'.format(mime_type, charset, data)


### PR DESCRIPTION
@The-Compiler could you take a look and see if you think this is a suitable fix for #27?