### PR TITLE
Allow unicode in test names

### DIFF
--- a/pytest_html/plugin.py
+++ b/pytest_html/plugin.py
@@ -146,6 +146,8 @@ class HTMLReport(object):
         additional_html.append(log)
 
         test_id = report.nodeid
+        if not PY3:
+            test_id = unicode(test_id, 'utf-8')
         if report.when != 'call':
             test_id = '::'.join([report.nodeid, report.when])
 


### PR DESCRIPTION
@The-Compiler unicode hurts my head! I encountered a test with `〈` as a parameter. This caused the report to fail due to `UnicodeDecodeError`. This patch fixes it, but would you mind taking a look to see if there's a smarter approach? I also found it difficult to write a test for this use case.